### PR TITLE
single button control for end-user

### DIFF
--- a/lib/generic_esp_32/generic_esp_32.h
+++ b/lib/generic_esp_32/generic_esp_32.h
@@ -29,9 +29,11 @@
 #include "presence_detection.h"
 #endif
 
-#define VERSION "V2.5.0"
-#define WIFI_RESET_BUTTON   GPIO_NUM_0
-#define LED_ERROR   GPIO_NUM_19
+#define VERSION "V2.6.0"
+#define BOOT   GPIO_NUM_0
+#define RED_LED_ERROR   GPIO_NUM_19
+#define LONG_BUTTON_PRESS_DURATION 19 // (10 s * 2 halfseconds - 1); this constant specifies the number of half seconds minus one to wait
+
 #define MAX_RESPONSE_LENGTH 100
 
 #define SSID_PREFIX "TWOMES-"
@@ -97,11 +99,11 @@ void sntp_sync_time(struct timeval *tv);
 
 
 #ifndef CONFIG_TWOMES_CUSTOM_GPIO
-#define OUTPUT_BITMASK ((1ULL<<LED_ERROR))
-#define INPUT_BITMASK ((1ULL << WIFI_RESET_BUTTON))
+#define OUTPUT_BITMASK ((1ULL<<RED_LED_ERROR))
+#define INPUT_BITMASK ((1ULL << BOOT))
 
 void initGPIO();
-void buttonPressDuration(void *args);
+void buttonPressHandlerGeneric(void *args);
 #endif
 void blink(void *args);
 char *get_types(char *stringf, int count);

--- a/platformio.ini
+++ b/platformio.ini
@@ -22,8 +22,9 @@ framework = espidf
 
 ;Build and Debug settings:
 build_flags = 
-    -DCORE_DEBUG_LEVEL=4                ;Uncomment to enable Debugging
-    -DLOG_LOCAL_LEVEL=4                 ;Uncomment to enable Debugging
+    -DCORE_DEBUG_LEVEL=4                ;Uncommented enables debugging
+    -DLOG_LOCAL_LEVEL=4                 ;Uncommented enables debugging
+;   -DCONFIG_TWOMES_CUSTOM_GPIO         ;Uncommented enables custom GPIO mapping 
     -DCONFIG_TWOMES_PROV_TRANSPORT_BLE  ;
     -DCONFIG_TWOMES_STRESS_TEST         ;line commented = disabled; line uncommented = enabled
     -DCONFIG_TWOMES_PRESENCE_DETECTION  ;line commented = disabled; line uncommented = enabled


### PR DESCRIPTION
Generic firmware was already single-button operation, but this PR includes the fixes that were made for the P1 gateway to include single-button operation. It also includes renaming of button and LED contants to follow the identifiers on the silkscreen printing on the PCBs 