### PR TITLE
Add devcontainer and dedicated readme

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,34 @@
+FROM ubuntu:20.04
+
+ARG USERNAME=vscode
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Install necessary software
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    git \
+    gnupg \
+    curl \
+    sudo \
+    python3 \
+    python3-pip \
+    python3-venv \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create a new sudo user with the right permissions
+RUN groupadd -g 986 ttyusb && \
+    useradd -ms /bin/bash -G dialout,plugdev,ttyusb $USERNAME \
+    && echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/$USERNAME
+
+USER $USERNAME
+
+WORKDIR /home/$USERNAME
+
+# Install ESPtool
+RUN pip3 install esptool
+
+# Install PlatformIO Core CLI
+RUN curl -fsSL https://raw.githubusercontent.com/platformio/platformio-core-installer/master/get-platformio.py -o get-platformio.py \
+    && python3 get-platformio.py \
+    && echo "export PATH=\$PATH:/home/$USERNAME/.platformio/penv/bin" >> ~/.bashrc \
+    && rm get-platformio.py

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,44 @@
+# VS Code Devcontainer
+
+## What is this
+
+A devcontainer lets you use a Docker container as a development environment. The container has all the necessary depencies installed and can easily be deleted when it is not needed.
+
+## How to use it
+
+### Prerequisites
+
+You will need the following prerequisites:
+
+-   [Docker desktop](https://docs.docker.com/desktop/) for MacOS or Windows or
+    [Docker](https://docs.docker.com/engine/) for Linux
+-   [VS Code](https://code.visualstudio.com/)
+-   [VS Code remote - containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+
+### Build and open the devcontainer
+
+1. Open the repository in VS Code.
+2. Click on `reopen in container` in the popup that will be displayed in the bottom right.
+    > The container has to be built the fist time you run it. This process can take around 10-15 minutes, but is largely dependent on your download speed and computer hardware. After building the container the first time, starting it again will be much faster.
+
+## Notes
+
+This container can be used to build the firmware on any plaftorm (Windows, MacOS or Linux). Windows and MacOS users can not use the devcontainer to deploy binary releases to a device. They should refer to [this](../README.md#deploying) section of the readme to deploy the firmware.
+
+On Linux, the devcontainer can also be used to deploy the firmware to a device. Uncomment the following lines in `.devcontainer.json` to enable this functionality:
+
+```diff
+// Uncommend the 6 lines below to use COM-ports (Linux and MacOS only)
+- // "mounts": [
+- //     "source=/dev,target=/dev,type=bind,consistency=consistent"
+- // ],
+- // "runArgs": [
+- //     "--privileged"
+- // ]
++ "mounts": [
++     "source=/dev,target=/dev,type=bind,consistency=consistent"
++ ],
++ "runArgs": [
++     "--privileged"
++ ]
+```

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+{
+    "name": "PlatformIO",
+
+    // Download container from GitHub Container Registry.
+    // "image": "ghcr.io/n-vr/platformio-devcontainer:latest",
+    
+    "build": {
+        "dockerfile": "Dockerfile",
+    },
+
+    // Install platformIO extension.
+    "extensions": [
+        "platformio.platformio-ide",
+    ],
+
+    // Expose PlatformIO Home port.
+    "forwardPorts": [
+        8010
+    ],
+
+    // Update your PlatformIO dependencies the first time the container is created.
+    "onCreateCommand": "pio run --target clean && pio platform update",
+
+    // Do not run as root.
+    "remoteUser": "vscode",
+
+    // Uncommend the 6 lines below to use COM-ports (Linux and MacOS only)
+    "mounts": [
+        "source=/dev,target=/dev,type=bind,consistency=consistent"
+    ],
+    "runArgs": [
+        "--privileged"
+    ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,5 +3,8 @@
     // for the documentation about the extensions.json format
     "recommendations": [
         "platformio.platformio-ide"
+    ],
+    "unwantedRecommendations": [
+        "ms-vscode.cpptools-extension-pack"
     ]
 }

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ If you want to repurpose and existing device (e.g. use it in another home), you 
 ## Developing 
 This section describes how you can change the source code using a development environment and compile the source code into a binary release of the firmware that can be deployed, either via the development environment, or via the method described in the section [Deploying](#deploying).
 
+> See [this](.devcontainer/README.md) section if you prefer to use a devcontainer.
+
 ### Prerequisites
 Prerequisites for deploying, plus:
 *	[Visual Studio Code](https://code.visualstudio.com/download) installed


### PR DESCRIPTION
- Add files so a devcontainer can be used.
- Describe how to use it in `.devcontainer/README.md`.
- Link to the devcontainer readme from the main readme.