### PR TITLE
Automated firmware release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: Create draft release with binary files
+# Trigger on new tag
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+env:
+  # Name of the archive .zip and .tar.gz archives without extension. Tag will be appended to this.
+  ARCHIVE_PREFIX: ${{ github.event.repository.name }}
+  
+  # Directory where the to-be-archived files are.
+  ARCHIVE_DIR: .pio/build/esp32dev
+
+  # Files that need to be archived.
+  ARCHIVE_FILES: bootloader.bin firmware.bin ota_data_initial.bin partitions.bin
+
+jobs:
+  build-and-draft-release:
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout repository.
+      - name: Checkout code
+        uses: actions/checkout@v2
+      
+      # Setup Python (needed by PlatformIO)
+      - name: Setup Python
+        uses: actions/setup-python@v2
+
+      # Setup PlatformIO.
+      - name: Setup PlatformIO
+        run: pip install platformio
+
+      # Cache build directory.
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: .pio
+          key: ${{ runner.os }}-${{ hashFiles('src/**') }}
+          restore-keys: |
+            ${{ runner.os }}
+      
+      # Build the PlatformIO project.
+      - name: Build PlatformIO project
+        run: pio run
+      
+      # Set ARCHIVE_NAME variable from ARCHIVE_PREFIX and tag name.
+      - name: Set ARCHIVE_NAME
+        run: echo "ARCHIVE_NAME=${ARCHIVE_PREFIX}_${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+
+      # Archive binary files.
+      - name: Archive binary files
+        run: |
+          cd $ARCHIVE_DIR
+          zip $ARCHIVE_NAME.zip $ARCHIVE_FILES
+#          tar -czvf $ARCHIVE_NAME.tar.gz $ARCHIVE_FILES
+      
+      # Create a release draft.
+      - name: Create draft release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          files: |
+            ${{ env.ARCHIVE_DIR }}/${{ env.ARCHIVE_NAME }}.zip
+#            ${{ env.ARCHIVE_DIR }}/${{ env.ARCHIVE_NAME }}.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,4 +62,5 @@ jobs:
           draft: true
           files: |
             ${{ env.ARCHIVE_DIR }}/${{ env.ARCHIVE_NAME }}.zip
+            .pio/build/esp32dev/firmware.bin
 #            ${{ env.ARCHIVE_DIR }}/${{ env.ARCHIVE_NAME }}.tar.gz

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ See [Twomes presence detection library](https://github.com/energietransitie/twom
 * [General info](#general-info)
 * [Deploying](#deploying)
 * [Developing](#developing) 
+* [Releasing](#releasing)
 * [Features](#features)
 * [Status](#status)
 * [License](#license)
@@ -205,6 +206,9 @@ Also note that we don't use the [POST /device/measurements/fixed-interval](https
 
 ### Other Things To Keep In Mind
 * Check the platformio.ini file in the cloned folder, look at the board_upload.flash_size, board_upload.maximum_size and board_build.partitions to check if they are right for your hardware.
+
+## Releasing
+Read more on how to create an automated release [here](RELEASING.md).
 
 ## Features
 Currently ready:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,45 @@
+# Release generic firmware for Twomes measurement devices
+GitHub actions can be used to automatically build and create a draft for a new release. This draft has to be verified by a member of the research group and released (not as a draft). At the time of verifying, a title and description can be added to the release.
+
+## Semantic versioning
+Always use a semantic version number when following the steps below! Read more about semantic versioning [here](https://semver.org). If you create a tag which is not a semantic version number prepended with "v" (e.g. "v1.0.0", "v1.3.12" or "v12.34.2"), Over-The-Air firmare updates will not work properly.
+
+## Initiating a build and draft release
+Follow the steps below to start the GitHub actions workflow which build the binaries and creates a draf release.
+
+### Prerequisites
+- [Git](https://git-scm.com/downloads)
+- [Git GPG signing](https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key) (recommended)
+
+### Steps
+1. If you have not already cloned the repository, do this now:
+    ```shell
+    git clone https://github.com/energietransitie/twomes-generic-esp-firmware.git
+    ```
+2. If you are not already on the main branch, checkout to the main branch:
+    ```shell
+    git checkout main
+    ```
+3. Make sure your main branch is up-to-date with the remote (typically origin):
+    ```shell
+    git pull origin main
+    ```
+4. Create a new tag with the new [semantic version number](#semantic-versioning):
+    ```shell
+    git tag -s v<semantic version> -m "<message>"
+    ```
+    > The message can contain a description of the tag.
+5. Upload the created tag to the remote (typically origin):
+    ```shell
+    git push origin <tag name>
+    ```
+
+## Verifying a draft release
+Only a member of the research group logged into GitHub can see draft releases.
+
+1. Go to the [releases page](https://github.com/energietransitie/twomes-generic-esp-firmware/releases).
+2. The latest draft release should be at the top of the page. Click on the pen icon in the top right of the release.
+3. You can now change the release title and description.
+4. The associated tag can be seen. Check if this is correct.
+5. The attached binaries can be viewed. Check if these are correct. There should be an archive `twomes-generic-esp-firmware_<version>.zip` and a `firmware.bin`.
+6. Click on `Publish release` to release the firmware version.


### PR DESCRIPTION
This pull-requests adds a GitHub actions workflow that automatically builds the assets and creates a draft release.
The readme was changed to add a link to an explanation on how to use this workflow.