### PR TITLE
Install CMake in the devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,6 +8,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install --no-install-recommends -y \
     git \
     gnupg \
+    cmake \
     curl \
     sudo \
     libusb-1.0-0 \


### PR DESCRIPTION
This is needed to use ESP-IDF from the command line
when building the secure bootloader.