### PR TITLE
Post provisioning actions

### DIFF
--- a/examples/presence_detector/src/main.cpp
+++ b/examples/presence_detector/src/main.cpp
@@ -6,11 +6,11 @@ constexpr const char *DEVICE_TYPE_NAME = "Presence-Detector";
 
 extern "C" void app_main(void)
 {
-	GenericESP32Firmware::Initialize(DEVICE_TYPE_NAME);
-
 	// Add the generic tasks to the scheduler,
 	// heartbeat, timesync and optionally presence detection and OTA updates.
 	GenericTasks::AddTasksToScheduler();
+
+	GenericESP32Firmware::Initialize(DEVICE_TYPE_NAME);
 
 	// Start the scheduler.
 	Scheduler::Start();

--- a/include/ota_firmware_updater.hpp
+++ b/include/ota_firmware_updater.hpp
@@ -9,7 +9,7 @@ namespace OTAFirmwareUpdater
 
     /**
      * Set the update check and download location.
-     * 
+     *
      * @param org GitHub organisation name.
      * @param repo GitHub repository name.
      * @param fileName Name of the GitHub release asset to download.
@@ -37,6 +37,14 @@ namespace OTAFirmwareUpdater
      * Check if the booted firmware needs to be veriefied or rolled back.
      */
     void CheckUpdateFinishedSuccessfully();
+
+    /**
+     * Log firmware version to twomes backend.
+     * 
+     * @param propertyName The name of the property. Can be "booted_fw" or "new_fw".
+     * @param version The version as a string.
+     */
+    void LogFirmwareToBackend(const std::string propertyName, const std::string &version);
 } // namespace OTAFirmwareUpdater
 
 #endif // OTA_FIRMWARE_UPDATER_HPP

--- a/include/scheduler.hpp
+++ b/include/scheduler.hpp
@@ -114,6 +114,11 @@ namespace Scheduler
 	Task *GetTask(const std::string &name);
 
 	/**
+	 * Clear all tasks that were added to the scheduler.
+	 */
+	void ClearTasks();
+
+	/**
 	 * Start the scheduler.
 	 *
 	 * This will start the tasks according to their scheduled interval.

--- a/include/scheduler.hpp
+++ b/include/scheduler.hpp
@@ -121,6 +121,12 @@ namespace Scheduler
 	void Start();
 
 	/**
+	 * Immediately run all the tasks that were added to the scheduler once
+	 * and wait for them to finish.
+	 */
+	void RunAll();
+
+	/**
 	 * Get the current task time.
 	 *
 	 * This is the time when this task interval was started.

--- a/src/generic_esp_32/generic_esp_32.cpp
+++ b/src/generic_esp_32/generic_esp_32.cpp
@@ -25,6 +25,10 @@
 #include <specific_m5coreink/rtc.h>
 #include <scheduler.hpp>
 
+#ifdef CONFIG_TWOMES_OTA_FIRMWARE_UPDATE
+#include <ota_firmware_updater.hpp>
+#endif // CONFIG_TWOMES_OTA_FIRMWARE_UPDATE
+
 #ifdef CONFIG_TWOMES_PROV_TRANSPORT_BLE
 #include <wifi_provisioning/scheme_ble.h>
 #endif // CONFIG_EXAMPLE_PROV_TRANSPORT_BLE
@@ -408,6 +412,11 @@ namespace GenericESP32Firmware
         {
             // Immediately sync time.
             InitializeTimeSync();
+#ifdef CONFIG_TWOMES_OTA_FIRMWARE_UPDATE
+            // Log the booted firmware version to the backend.
+            auto appDescription = esp_ota_get_app_description();
+            OTAFirmwareUpdater::LogFirmwareToBackend("booted_fw", appDescription->version);
+#endif // CONFIG_TWOMES_OTA_FIRMWARE_UPDATE
 
             // Run all tasks in the scheduler once.
             Scheduler::RunAll();
@@ -590,6 +599,10 @@ namespace GenericESP32Firmware
         // otherwise booting by the RTC signal will not succeed.
         powerpin_set();
 #endif // M5STACK_COREINK
+
+#ifdef CONFIG_TWOMES_OTA_FIRMWARE_UPDATE
+        OTAFirmwareUpdater::CheckUpdateFinishedSuccessfully();
+#endif // CONFIG_TWOMES_OTA_FIRMWARE_UPDATE
 
         s_deviceTypeName = deviceTypeName;
 

--- a/src/generic_tasks/generic_tasks.cpp
+++ b/src/generic_tasks/generic_tasks.cpp
@@ -52,6 +52,8 @@ namespace GenericTasks
 
 	void AddTasksToScheduler()
 	{
+		Scheduler::ClearTasks();
+
 #ifdef M5STACK_COREINK
 		Scheduler::AddTask(TimeSyncTask,
 						   "Time sync task",

--- a/src/ota_firmware_updater/ota_firmware_updater.cpp
+++ b/src/ota_firmware_updater/ota_firmware_updater.cpp
@@ -46,12 +46,6 @@ namespace OTAFirmwareUpdater
 
         auto secureUploadQueue = SecureUpload::Queue::GetInstance();
 
-        void LogFirmwareToBackend(const std::string propertyName, const std::string &version)
-        {
-            Measurements::Measurement measurement(propertyName, version);
-            secureUploadQueue.AddMeasurement(measurement);
-        }
-
         update_available_t FindUpdates()
         {
             ESP_LOGI(TAG, "Checking for available updates.");
@@ -273,5 +267,14 @@ namespace OTAFirmwareUpdater
             // If marking valid fails, mark invalid.
             esp_ota_mark_app_invalid_rollback_and_reboot();
         }
+    }
+
+    void LogFirmwareToBackend(const std::string propertyName, const std::string &version)
+    {
+        // Initialize Measurement formatter.
+        Measurements::Measurement::AddFormatter(propertyName, "%s");
+
+        Measurements::Measurement measurement(propertyName, version.c_str());
+        secureUploadQueue.AddMeasurement(measurement);
     }
 } // namespace OTAFirmwareUpdater

--- a/src/scheduler/scheduler.cpp
+++ b/src/scheduler/scheduler.cpp
@@ -235,6 +235,11 @@ namespace Scheduler
 		return nullptr;
 	}
 
+	void ClearTasks()
+	{
+		s_tasks.clear();
+	}
+
 	void Start()
 	{
 		xTaskCreatePinnedToCore(SchedulerTask,


### PR DESCRIPTION
The firmware can now detect when provisioning just happened. The following will happen when that is detected:
- If OTA firmware updates are enabled, the current firmware version will be logged to the backend.
- All tasks will run once immediately.