### PR TITLE
Create generic battery voltage task

### DIFF
--- a/include/specific_m5coreink/battery_voltage.hpp
+++ b/include/specific_m5coreink/battery_voltage.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace M5CoreInkSpecific
+{
+    /**
+     * Battery voltage task.
+     * 
+     * This will measure the battery voltage
+     * and add the value to the secure upload queue.
+     */
+    void BatteryVoltageTask(void *taskInfo);
+} // namespace M5CoreInkSpecific

--- a/src/generic_tasks/generic_tasks.cpp
+++ b/src/generic_tasks/generic_tasks.cpp
@@ -5,6 +5,10 @@
 #include <secure_upload.hpp>
 #include <generic_esp_32.hpp>
 
+#ifdef M5STACK_COREINK
+#include <specific_m5coreink/battery_voltage.hpp>
+#endif // M5STACK_COREINK
+
 #ifdef CONFIG_TWOMES_PRESENCE_DETECTION
 #include <presence_detection.hpp>
 #endif // CONFIG_TWOMES_PRESENCE_DETECTION
@@ -61,6 +65,13 @@ namespace GenericTasks
 						   nullptr,
 						   1,
 						   Scheduler::Interval::HOURS_24);
+
+		Scheduler::AddTask(M5CoreInkSpecific::BatteryVoltageTask,
+						   "Battery voltage task",
+						   4096,
+						   nullptr,
+						   1,
+						   Scheduler::Interval::MINUTES_10);
 #endif // M5STACK_COREINK
 
 #ifdef CONFIG_TWOMES_PRESENCE_DETECTION

--- a/src/specific_m5coreink/battery_voltage.cpp
+++ b/src/specific_m5coreink/battery_voltage.cpp
@@ -1,0 +1,46 @@
+#include <specific_m5coreink/battery_voltage.hpp>
+
+#include <driver/adc.h>
+#include <esp_adc_cal.h>
+
+#include <secure_upload.hpp>
+#include <measurements.hpp>
+
+constexpr const char *MEASUREMENT_PROPERTY_NAME = "batteryVoltage";
+
+namespace M5CoreInkSpecific
+{
+    namespace
+    {
+        static bool s_initialized = false;
+        static esp_adc_cal_characteristics_t s_adcChars;
+
+        auto secureUploadQueue = SecureUpload::Queue::GetInstance();
+    } // namespace
+
+    void BatteryVoltageTask(void *taskInfo)
+    {
+        if (!s_initialized)
+        {
+            // Setup ADC1 channel 7 (gpio35).
+            adc1_config_channel_atten(ADC1_CHANNEL_7, ADC_ATTEN_11db);
+
+            // Calculate characteristic of adc1.
+            esp_adc_cal_characterize(ADC_UNIT_1, ADC_ATTEN_DB_11, ADC_WIDTH_BIT_12, 3600, &s_adcChars);
+
+            // Add a formatter for the batteryVoltage property.
+            Measurements::Measurement::AddFormatter(MEASUREMENT_PROPERTY_NAME, "%.2f");
+
+            s_initialized = true;
+        }
+
+        // Measure battery voltage.
+        auto rawMeasurement = adc1_get_raw(ADC1_CHANNEL_7);
+        auto rawVoltage_mV = esp_adc_cal_raw_to_voltage(rawMeasurement, &s_adcChars);
+        auto batteryVoltage = ((float)rawVoltage_mV) * 25.1 / 5.1 / 1000;
+
+        // Send data to queue.
+        Measurements::Measurement batteryVoltageMeasurement(MEASUREMENT_PROPERTY_NAME, batteryVoltage);
+        secureUploadQueue.AddMeasurement(batteryVoltageMeasurement);
+    }
+} // namespace M5CoreInkSpecific


### PR DESCRIPTION
This task will be added to the scheduler by GenericTasks::AddTasksToScheduler().
This will only happen when the platform is M5STACK_COREINK.

This task was created with code from here:
https://github.com/energietransitie/twomes-generic-esp-firmware/commit/29996da8a87529c96fb6e9ef4448f02b0726fc57
https://github.com/energietransitie/twomes-generic-esp-firmware/commit/aeb3fc1f0ceb74f5c61621f960cd3f9c02c3d5cb

Co-authored-by: Tiemen-M <43133327+Tiemen-M@users.noreply.github.com>
Co-authored-by: Henri ter Hofte <h.ter.hofte@windesheim.nl>