### PR TITLE
Fix Bluetooth name requests being unreliable

### DIFF
--- a/examples/presence_detector/platformio.ini
+++ b/examples/presence_detector/platformio.ini
@@ -43,6 +43,7 @@ build_flags =
 ;   -DCONFIG_TWOMES_PROV_TRANSPORT_SOFTAP ; uncomment line to support SoftAP provisioning
 ;   -DCONFIG_TWOMES_STRESS_TEST         ;line commented = disabled; line uncommented = enabled
     -DCONFIG_TWOMES_PRESENCE_DETECTION  ;line commented = disabled; line uncommented = enabled
+;   -DCONFIG_TWOMES_PRESENCE_DETECTION_PARALLEL ;line commented = disabled; line uncommented = enabled; keep disabled for now
     -DCONFIG_TWOMES_TEST_SERVER         ;line uncommented = use test server; line commented = use other server
 ;   -DCONFIG_TWOMES_PRODUCTION_SERVER   ;line uncommented = use production server; line commented = use other server
 ;   -DCONFIG_TWOMES_OTA_FIRMWARE_UPDATE ;line commented = disabled; line uncommented = enabled


### PR DESCRIPTION
I noticed problems with Bluetooth presence detection.
After some testing, doing parallel name requests proved unreliable.

I added the option to do it in parallel, which is disabled for now.
It is way more reliable when working sequentially.