### PR TITLE
Fix scheduler

### DIFF
--- a/src/generic_tasks/generic_tasks.cpp
+++ b/src/generic_tasks/generic_tasks.cpp
@@ -56,8 +56,6 @@ namespace GenericTasks
 
 	void AddTasksToScheduler()
 	{
-		Scheduler::ClearTasks();
-
 #ifdef M5STACK_COREINK
 		Scheduler::AddTask(TimeSyncTask,
 						   "Time sync task",

--- a/src/scheduler/scheduler.cpp
+++ b/src/scheduler/scheduler.cpp
@@ -217,6 +217,13 @@ namespace Scheduler
 			return;
 		}
 
+		if (GetTask(name) != nullptr)
+		{
+			// Task is already added. We can skip this.
+			ESP_LOGD(TAG, "Task with name \"%s\" was already started. Skipping now.", name.c_str());
+			return;
+		}
+
 		Task task = {function, name, stackDepth, params, priority, interval_s, id};
 
 		s_tasks.push_back(std::move(task));


### PR DESCRIPTION
The scheduler now skips adding duplicate tasks.
It also does not clear all other tasks when generic tasks are added.