### PR TITLE
Send heartbeat separately after provisioning

### DIFF
--- a/include/generic_tasks.hpp
+++ b/include/generic_tasks.hpp
@@ -3,6 +3,21 @@
 namespace GenericTasks
 {
     /**
+     * Task that uploads everything on the upload queue.
+     */
+    void UploadTask(void *taskInfo);
+
+    /**
+     * Task to create a heartbeat and put in on the upload queue.
+     */
+    void HeartbeatTask(void *taskInfo);
+
+    /**
+     * Task to sync the current time using NTP.
+     */
+    void TimeSyncTask(void *taskInfo);
+
+    /**
      * Start the generic tasks by adding them to the scheduler.
      */
     void AddTasksToScheduler();

--- a/src/generic_esp_32/generic_esp_32.cpp
+++ b/src/generic_esp_32/generic_esp_32.cpp
@@ -24,6 +24,9 @@
 #include <specific_m5coreink/powerpin.h>
 #include <specific_m5coreink/rtc.h>
 #include <scheduler.hpp>
+#include <generic_tasks.hpp>
+#include <measurements.hpp>
+#include <secure_upload.hpp>
 
 #ifdef CONFIG_TWOMES_OTA_FIRMWARE_UPDATE
 #include <ota_firmware_updater.hpp>
@@ -439,6 +442,14 @@ namespace GenericESP32Firmware
             auto appDescription = esp_ota_get_app_description();
             OTAFirmwareUpdater::LogFirmwareToBackend("booted_fw", appDescription->version);
 #endif // CONFIG_TWOMES_OTA_FIRMWARE_UPDATE
+
+            ESP_LOGD(TAG, "Sending a heartbeat once.");
+            // Add a measurement formatter for the heartbeat property.
+            Measurements::Measurement::AddFormatter("heartbeat", "%d");
+
+            Measurements::Measurement measurement("heartbeat", 0, time(nullptr));
+            SecureUpload::Queue::GetInstance().AddMeasurement(measurement);
+            GenericTasks::UploadTask(nullptr);
 
             // Run all tasks in the scheduler once.
             Scheduler::RunAll();

--- a/src/scheduler/scheduler.cpp
+++ b/src/scheduler/scheduler.cpp
@@ -316,18 +316,27 @@ namespace Scheduler
 
 	std::string GetName(void *&taskInfo)
 	{
+		if (taskInfo == nullptr)
+			return "";
+
 		auto info = reinterpret_cast<TaskWrapperInfo *>(taskInfo);
 		return info->name;
 	}
 
 	void *GetParams(void *&taskInfo)
 	{
+		if (taskInfo == nullptr)
+			return nullptr;
+
 		auto info = reinterpret_cast<TaskWrapperInfo *>(taskInfo);
 		return info->params;
 	}
 
 	uint32_t GetID(void *&taskInfo)
 	{
+		if (taskInfo == nullptr)
+			return -1;
+
 		auto info = reinterpret_cast<TaskWrapperInfo *>(taskInfo);
 		return info->id;
 	}
@@ -349,6 +358,9 @@ namespace Scheduler
 
 	void WaitForOtherTasks(void *&taskInfo)
 	{
+		if (taskInfo == nullptr)
+			return;
+
 		WaitForOtherTasks(GetID(taskInfo));
 	}
 


### PR DESCRIPTION
## What does this change
Previously every measurement was done once and then sent. When provisioning a new device with the WarmteWachter app, this would cause a long delay before the final check mark would appear.

This change makes sure that a heartbeat is sent right after provisioning. Only after the heartbeat was successfully sent, will the rest of the measurements be sent. This makes sure that the final check mark in the WarmteWachter app is quickly checked.

## How to test this PR
This pull request can be tested by building an example or any project that uses this library. Reset the device's provisioning by long-pressing the button at the top of the M5Stack coreINK. When you provision the device again, the desired behavior can be observed; the device will first send a heartbeat before doing all the measurements.

## Trello card(s)
- Immediately followed by provisioning: upload heartbeat separately first, then followed by performing all measurement tasks once: https://trello.com/c/zU8GZMZe