### PR TITLE
Fix buttons

### DIFF
--- a/include/util/buttons.hpp
+++ b/include/util/buttons.hpp
@@ -11,9 +11,6 @@
 
 namespace Buttons
 {
-    // Forward declare so the Button struct can use it.
-    class ButtonPressHandler;
-
     using ButtonCallback_t = void (*)();
 
     /**
@@ -21,7 +18,6 @@ namespace Buttons
      */
     struct Button
     {
-        ButtonPressHandler *handler;
         gpio_num_t gpioNum;
         std::string name;
         int trigger;
@@ -35,14 +31,8 @@ namespace Buttons
      * Handles buttons using interrupts.
      * Can detect short or long presses and use callbacks.
      */
-    class ButtonPressHandler
+    namespace ButtonPressHandler
     {
-    public:
-        /**
-         * Initialize ButtonPressHandler.
-         */
-        ButtonPressHandler();
-
         /**
          * Add a new button to the handler.
          *
@@ -59,31 +49,5 @@ namespace Buttons
                             int trigger,
                             ButtonCallback_t cbShort,
                             ButtonCallback_t cbLong);
-
-    private:
-        /**
-         * FreeRTOS task that is used to handle button presses.
-         *
-         * @param pvParams Task parameters.
-         */
-        friend void ButtonPressHandlerTask(void *pvParams);
-
-        /**
-         * Interrupt service handler for button presses.
-         *
-         * @param pvParams Task parameters.
-         */
-        friend void IRAM_ATTR ISRHandlerGPIO(void *pvParams);
-
-    private:
-        /**
-         * Event queue used by the ISR and handler task.
-         */
-        xQueueHandle m_gpioEventQueue;
-
-        /**
-         * Vector to keep track of all buttons.
-         */
-        std::vector<std::unique_ptr<Button>> m_buttons;
     };
 } // namespace Buttons

--- a/src/generic_esp_32/generic_esp_32.cpp
+++ b/src/generic_esp_32/generic_esp_32.cpp
@@ -94,8 +94,6 @@ namespace GenericESP32Firmware
 
         static bool s_postProvisioningNeeded = false;
 
-        static Buttons::ButtonPressHandler *s_buttonPressHandler;
-
         /**
          * Blink an LED on the device.
          *
@@ -340,8 +338,6 @@ namespace GenericESP32Firmware
 #ifndef CONFIG_TWOMES_CUSTOM_GPIO
             ESP_LOGD(TAG, "Initializing GPIO.");
 
-            s_buttonPressHandler = new Buttons::ButtonPressHandler();
-
 #ifdef ESP32DEV
             auto err = ESP32Dev::InitializeGPIO();
 #endif // ESP32DEV
@@ -352,7 +348,7 @@ namespace GenericESP32Firmware
             if (Error::CheckAppendName(err, TAG, "An error occured when initializing GPIO"))
                 return err;
 
-            err = s_buttonPressHandler->AddButton(BUTTON_WIFI_RESET, "Wi-Fi reset", 0, nullptr, ResetWireless);
+            err = Buttons::ButtonPressHandler::AddButton(BUTTON_WIFI_RESET, "Wi-Fi reset", 0, nullptr, ResetWireless);
             if (Error::CheckAppendName(err, TAG, "An error occured when adding BUTTON_WIFI_RESET to handler"))
                 return err;
 #endif // CONFIG_TWOMES_CUSTOM_GPIO

--- a/src/util/buttons.cpp
+++ b/src/util/buttons.cpp
@@ -52,7 +52,7 @@ namespace Buttons
                     vTaskDelay(Delay::MilliSeconds(500));
 
                     // Call the buttons callback based on the duration of the press.
-                    if (halfSeconds >= LONG_BUTTON_PRESS_DURATION)
+                    if (halfSeconds == LONG_BUTTON_PRESS_DURATION)
                     {
                         if (button->longPressCallback == nullptr)
                         {

--- a/src/util/buttons.cpp
+++ b/src/util/buttons.cpp
@@ -11,128 +11,145 @@ constexpr int LONG_BUTTON_PRESS_DURATION = 10 * 2; // Number of half seconds min
 
 namespace Buttons
 {
-    /**
-     * Interrupt service handler for button presses.
-     */
-    void IRAM_ATTR ISRHandlerGPIO(void *pvParams)
+    namespace
     {
-        auto button = (Button *)pvParams;
+        // Event queue used by the ISR and handler task.
+        static xQueueHandle s_gpioEventQueue;
 
-        xQueueSendFromISR(button->handler->m_gpioEventQueue, pvParams, NULL);
-    }
+        // Vector to keep track of all buttons.
+        static std::vector<std::shared_ptr<Button>> s_buttons;
 
-    /**
-     * FreeRTOS task that is used to handle button presses.
-     */
-    void ButtonPressHandlerTask(void *pvParams)
-    {
-        auto handler = (ButtonPressHandler *)pvParams;
-
-        auto button = new Button;
-
-        while (true)
+        /**
+         * Interrupt service handler for button presses.
+         *
+         * @param pvParams Task parameters.
+         */
+        void IRAM_ATTR ISRHandlerGPIO(void *pvParams)
         {
-            // Wait for an event on the queue.
-            xQueueReceive(handler->m_gpioEventQueue, button, portMAX_DELAY);
+            xQueueSendFromISR(s_gpioEventQueue, pvParams, NULL);
+        }
 
-            // Debounce: nothing happens when button is pressed < 0.1 s
-            vTaskDelay(Delay::MilliSeconds(100));
+        /**
+         * FreeRTOS task that is used to handle button presses.
+         */
+        void ButtonPressHandlerTask(void *pvParams)
+        {
+            auto button = new Button;
 
-            for (int halfSeconds = 1; gpio_get_level(button->gpioNum) == button->trigger; halfSeconds++)
+            while (true)
             {
-                // Button is still pressed.
+                // Wait for an event on the queue.
+                xQueueReceive(s_gpioEventQueue, button, portMAX_DELAY);
 
-                // Wait for half a second to pass.
-                vTaskDelay(Delay::MilliSeconds(500));
+                // Debounce: nothing happens when button is pressed < 0.1 s
+                vTaskDelay(Delay::MilliSeconds(100));
 
-                // Call the buttons callback based on the duration of the press.
-                if (halfSeconds >= LONG_BUTTON_PRESS_DURATION)
+                for (int halfSeconds = 1; gpio_get_level(button->gpioNum) == button->trigger; halfSeconds++)
                 {
-                    if (button->longPressCallback == nullptr)
+                    // Button is still pressed.
+
+                    // Wait for half a second to pass.
+                    vTaskDelay(Delay::MilliSeconds(500));
+
+                    // Call the buttons callback based on the duration of the press.
+                    if (halfSeconds >= LONG_BUTTON_PRESS_DURATION)
                     {
+                        if (button->longPressCallback == nullptr)
+                        {
+                            ESP_LOGD(TAG,
+                                     "Long press was detected for button \"%s\", but no long press callback was defined.",
+                                     button->name.c_str());
+                            break;
+                        }
+
                         ESP_LOGD(TAG,
-                                 "Long press was detected for button \"%s\", but no long press callback was defined.",
+                                 "Long press was detected for button \"%s\". Invoking callback.",
                                  button->name.c_str());
-                        break;
+                        button->longPressCallback();
                     }
-
-                    ESP_LOGD(TAG,
-                             "Long press was detected for button \"%s\". Invoking callback.",
-                             button->name.c_str());
-                    button->longPressCallback();
-                }
-                else if (gpio_get_level(button->gpioNum) != button->trigger)
-                {
-                    // Button was released before it was considered a long press.
-
-                    if (button->shortPressCallback == nullptr)
+                    else if (gpio_get_level(button->gpioNum) != button->trigger)
                     {
-                        ESP_LOGD(TAG,
-                                 "Short press was detected for button \"%s\", but no short press callback was defined.",
-                                 button->name.c_str());
-                        break;
-                    }
+                        // Button was released before it was considered a long press.
 
-                    ESP_LOGD(TAG,
-                             "Short press was detected for button \"%s\". Invoking callback.",
-                             button->name.c_str());
-                    button->shortPressCallback();
+                        if (button->shortPressCallback == nullptr)
+                        {
+                            ESP_LOGD(TAG,
+                                     "Short press was detected for button \"%s\", but no short press callback was defined.",
+                                     button->name.c_str());
+                            break;
+                        }
+
+                        ESP_LOGD(TAG,
+                                 "Short press was detected for button \"%s\". Invoking callback.",
+                                 button->name.c_str());
+                        button->shortPressCallback();
+                    }
                 }
             }
         }
-    }
+    } // namespace
 
-    ButtonPressHandler::ButtonPressHandler()
+    namespace ButtonPressHandler
     {
-        m_gpioEventQueue = xQueueCreate(10, sizeof(Button));
+        namespace
+        {
+            static bool s_initialized = false;
 
-        auto err = gpio_install_isr_service(0);
-        Error::CheckAppendName(err, TAG, "An error occured when installing isr service");
+            void Init()
+            {
+                s_gpioEventQueue = xQueueCreate(10, sizeof(Button));
 
-        err = xTaskCreatePinnedToCore(ButtonPressHandlerTask,
-                                      "ButtonPressHandlerTask",
-                                      2048,
-                                      (void *)this,
-                                      10,
-                                      nullptr,
-                                      APP_CPU_NUM);
-        if (err != pdPASS)
-            ESP_LOGE(TAG, "An error occured when starting button press handler task");
-    }
+                auto err = gpio_install_isr_service(0);
+                Error::CheckAppendName(err, TAG, "An error occured when installing isr service");
 
-    esp_err_t ButtonPressHandler::AddButton(gpio_num_t gpioNum,
-                                            const std::string &name,
-                                            int trigger,
-                                            ButtonCallback_t cbShort,
-                                            ButtonCallback_t cbLong)
-    {
-        std::unique_ptr<Button> button(new Button);
-        button->handler = this;
-        button->gpioNum = gpioNum;
-        button->name = name;
-        button->trigger = trigger;
-        button->shortPressCallback = cbShort;
-        button->longPressCallback = cbLong;
+                err = xTaskCreatePinnedToCore(ButtonPressHandlerTask,
+                                              "ButtonPressHandlerTask",
+                                              2048,
+                                              nullptr,
+                                              10,
+                                              nullptr,
+                                              APP_CPU_NUM);
+                if (err != pdPASS)
+                    ESP_LOGE(TAG, "An error occured when starting button press handler task");
+            }
+        } // namespace
 
-        ESP_LOGD(TAG, "Button added.\n"
-                      "\tGPIO num: %d\n"
-                      "\tName: %s\n"
-                      "\tTrigger: %d\n"
-                      "\tShort press callback: %s\n"
-                      "\tLong press callback: %s",
-                 button->gpioNum,
-                 button->name.c_str(),
-                 button->trigger,
-                 button->shortPressCallback ? "true" : "false",
-                 button->longPressCallback ? "true" : "false");
+        esp_err_t AddButton(gpio_num_t gpioNum,
+                            const std::string &name,
+                            int trigger,
+                            ButtonCallback_t cbShort,
+                            ButtonCallback_t cbLong)
+        {
+            if (!s_initialized)
+                Init();
 
-        // Add it to m_buttons so memory can be freed if needed.
-        m_buttons.push_back(std::move(button));
+            std::unique_ptr<Button> button(new Button);
+            button->gpioNum = gpioNum;
+            button->name = name;
+            button->trigger = trigger;
+            button->shortPressCallback = cbShort;
+            button->longPressCallback = cbLong;
 
-        auto err = gpio_isr_handler_add(gpioNum, ISRHandlerGPIO, m_buttons.back().get());
-        if (Error::CheckAppendName(err, TAG, "An error occured when adding isr handler"))
-            return err;
+            ESP_LOGD(TAG, "Button added.\n"
+                          "\tGPIO num: %d\n"
+                          "\tName: %s\n"
+                          "\tTrigger: %d\n"
+                          "\tShort press callback: %s\n"
+                          "\tLong press callback: %s",
+                     button->gpioNum,
+                     button->name.c_str(),
+                     button->trigger,
+                     button->shortPressCallback ? "true" : "false",
+                     button->longPressCallback ? "true" : "false");
 
-        return ESP_OK;
-    }
+            // Add it to m_buttons so memory can be freed if needed.
+            s_buttons.push_back(std::move(button));
+
+            auto err = gpio_isr_handler_add(gpioNum, ISRHandlerGPIO, s_buttons.back().get());
+            if (Error::CheckAppendName(err, TAG, "An error occured when adding isr handler"))
+                return err;
+
+            return ESP_OK;
+        }
+    } // namespace ButtonPressHandler
 } // namespace Buttons


### PR DESCRIPTION
[Turn button press handler into non-class](https://github.com/energietransitie/twomes-generic-esp-firmware/commit/e3bf135e035fef253fa0c62a688774b8871a75f5) 

Before this change, a new handler would have to be created for each translation unit.
These handlers and their interrupts would conflict with each other.

This change makes sure there is only one handler, and prevents these issues.

Some dependent code also had to be changed in order to adapt to this.
@[n-vr](https://github.com/energietransitie/twomes-generic-esp-firmware/commits?author=n-vr)
n-vr committed 4 hours ago
  
[Avoid triggering multiple long presses](https://github.com/energietransitie/twomes-generic-esp-firmware/commit/03d2520ae66bd303a05044095d4adaffa360b18a) 

The long press callback could be triggered repeatedly
when the button was held longer than the long press duration.
@[n-vr](https://github.com/energietransitie/twomes-generic-esp-firmware/commits?author=n-vr)
n-vr committed 3 hours ago