### PR TITLE
Add software support for the buzzer in M5CoreINK

### DIFF
--- a/include/util/buzzer.hpp
+++ b/include/util/buzzer.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <esp_err.h>
+
+namespace Buzzer
+{
+    /**
+     * Configure the buzzer. 
+     * This only works on M5STACK_COREINK.
+     */
+    void Configure();
+
+    /**
+     * Buzz the buzzer for specified amount of milliseconds.
+     * 
+     * @param milliseconds Milliseconds to buzz the buzzer.
+     */
+    void Buzz(int milliseconds);
+
+    /**
+     * Buzz the buzzer for specified amount of milliseconds, a specified amount of times.
+     * 
+     * @param milliseconds Milliseconds to buzz the buzzer.
+     * @param count Amount of times to buzz the buzzer.
+     */
+    void Buzz(int milliseconds, int count);
+} // namespace Buzzer

--- a/src/util/buzzer.cpp
+++ b/src/util/buzzer.cpp
@@ -1,0 +1,79 @@
+#include <util/buzzer.hpp>
+
+#include <driver/gpio.h>
+#include <driver/ledc.h>
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
+#include <util/error.hpp>
+#include <util/delay.hpp>
+
+namespace Buzzer
+{
+    namespace
+    {
+        void BuzzerOn()
+        {
+            ledc_set_duty(LEDC_HIGH_SPEED_MODE, LEDC_CHANNEL_0, 0x3ff);
+            ledc_update_duty(LEDC_HIGH_SPEED_MODE, LEDC_CHANNEL_0);
+        }
+
+        void BuzzerOff()
+        {
+            ledc_set_duty(LEDC_HIGH_SPEED_MODE, LEDC_CHANNEL_0, 0);
+            ledc_update_duty(LEDC_HIGH_SPEED_MODE, LEDC_CHANNEL_0);
+        }
+    } // namespace
+
+    void Configure()
+    {
+        // Configure GPIO for buzzer.
+        gpio_config_t gpioConfigBuzzer = {};
+        gpioConfigBuzzer.intr_type = GPIO_INTR_DISABLE;
+        gpioConfigBuzzer.mode = GPIO_MODE_OUTPUT;
+        gpioConfigBuzzer.pin_bit_mask = GPIO_SEL_2;
+        gpioConfigBuzzer.pull_down_en = GPIO_PULLDOWN_ENABLE;
+        auto err = gpio_config(&gpioConfigBuzzer);
+        Error::CheckAppendName(err, "Main", "An error occured when configuring GPIO for buzzer.");
+
+        // Configure LEDC (PWM) timer for buzzer.
+        ledc_timer_config_t timerConfig{};
+        timerConfig.speed_mode = LEDC_HIGH_SPEED_MODE;
+        timerConfig.timer_num = LEDC_TIMER_0;
+        timerConfig.duty_resolution = LEDC_TIMER_13_BIT;
+        timerConfig.freq_hz = 1000;
+        timerConfig.clk_cfg = LEDC_AUTO_CLK;
+        err = ledc_timer_config(&timerConfig);
+        Error::CheckAppendName(err, "Main", "An error occured when configuring LEDC timer for buzzer.");
+
+        ledc_channel_config_t channelConfig{};
+        channelConfig.speed_mode = LEDC_HIGH_SPEED_MODE;
+        channelConfig.channel = LEDC_CHANNEL_0;
+        channelConfig.timer_sel = LEDC_TIMER_0;
+        channelConfig.intr_type = LEDC_INTR_DISABLE;
+        channelConfig.gpio_num = GPIO_NUM_2;
+        channelConfig.duty = 0;
+        channelConfig.hpoint = 0x1fff;
+        err = ledc_channel_config(&channelConfig);
+        Error::CheckAppendName(err, "Main", "An error occured when configuring LEDC channel for buzzer.");
+    }
+
+    void Buzz(int milliseconds)
+    {
+        BuzzerOn();
+
+        vTaskDelay(Delay::MilliSeconds(milliseconds));
+
+        BuzzerOff();        
+    }
+
+    void Buzz(int milliseconds, int count)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            Buzz(milliseconds);
+            vTaskDelay(Delay::MilliSeconds(milliseconds));
+        }
+    }
+} // namespace Buzzer


### PR DESCRIPTION
## What does this change
This PR adds support for the buzzer on the M5Stack Core INK.

:warning: This code is already used by the [co2 monitor firmware repository](https://github.com/energietransitie/twutility-twomes-co2-bt-occupancy-monitor-firmware/tree/use-generic-library) on the [`use-generic-library`](https://github.com/energietransitie/twutility-twomes-co2-bt-occupancy-monitor-firmware/tree/use-generic-library) branch. That branch will currently only compile when the change in the testing section below is made.

## Testing
These changes can be tested by using the [co2 monitor firmware repository](https://github.com/energietransitie/twutility-twomes-co2-bt-occupancy-monitor-firmware/tree/use-generic-library) on the [`use-generic-library`](https://github.com/energietransitie/twutility-twomes-co2-bt-occupancy-monitor-firmware/tree/use-generic-library) branch.
1. Make the following change to the `platformio.ini` file.
    ```diff
    - https://github.com/energietransitie/twomes-generic-esp-firmware
    + https://github.com/energietransitie/twomes-generic-esp-firmware#buzzer
    ```
2. Compile the firmware and flash it onto a device.
3. When you hold 'up' on the multi-functional button for 10 seconds, you will hear a beep when recalibration starts. You will hear 2 beeps when calibration finishes successfully and 3 if it fails. Recalibration can take between 3 and 4 minutes. See chapter 3.7.1 in the [SCD41 datasheet](https://sensirion.com/media/documents/C4B87CE6/627C2DCD/CD_DS_SCD40_SCD41_Datasheet_D1.pdf) to read why.