### PR TITLE
Add CNAME file for MkDocs and gh-pages

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+www.energietransitiewindesheim.nl


### PR DESCRIPTION
MkDocs requires you to put a CNAME file in your docs dir. This is most likely what caused the site not to work.

This is supposed to fix the problems talked about in #56 