### PR TITLE
Fix link to secure boot docs

### DIFF
--- a/bootloader/README.md
+++ b/bootloader/README.md
@@ -1,2 +1,2 @@
 # Secure bootloader
-This folder contains configuration files you need to [build a secure bootloader with ESP-IDF](https://www.energietransitiewindesheim.nl/twomes-generic-esp-firmware/deploying/secure-boot.md).
+This folder contains configuration files you need to [build a secure bootloader with ESP-IDF](https://www.energietransitiewindesheim.nl/twomes-generic-esp-firmware/releasing/secure-boot-bootloader/).


### PR DESCRIPTION
This PR fixes the link in bootloader/README.md to the secure boot documentation on https://www.energietransitiewindesheim.nl/twomes-generic-esp-firmware.