### PR TITLE
Do not run build workflow for markdown files

### DIFF
--- a/.github/workflows/build-skip.yml
+++ b/.github/workflows/build-skip.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [ main ]
     paths:
-      - '*.md'
+      - '**.md'
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches: [ main ]
     paths-ignore:
-      - '*.md'
+      - '**.md'
   pull_request:
     branches: [ main ]
     paths-ignore:
-      - '*.md'
+      - '**.md'
   schedule:
     - cron: '0 8 * * 1'
 


### PR DESCRIPTION
The paths matcher was '*.md', which does not match all .md-filed. This was changed to '**.md' wich does match all .md-files.