### PR TITLE
Set current timestamp based on scheduler start

### DIFF
--- a/include/scheduler.hpp
+++ b/include/scheduler.hpp
@@ -39,47 +39,6 @@ namespace Scheduler
 		uint32_t priority;
 		Interval interval_s;
 		uint32_t id;
-
-		// // Constructor that allows to move name instead
-		// Task(TaskFunction_t function,
-		// 	 std::string &&name,
-		// 	 uint32_t stackDepth,
-		// 	 void *params,
-		// 	 uint32_t priority,
-		// 	 Interval interval_s,
-		// 	 uint32_t id)
-		// 	: function(function),
-		// 	  name(name),
-		// 	  stackDepth(stackDepth),
-		// 	  params(params),
-		// 	  priority(priority),
-		// 	  interval_s(interval_s),
-		// 	  id(id) {}
-	};
-
-	/**
-	 * Helper class with method Needed() to see if init is needed.
-	 */
-	class Init
-	{
-	public:
-		/**
-		 * Check if initialization needs to be done or not.
-		 *
-		 * @returns True if initialization is needed. False if already initialized.
-		 */
-		bool Needed()
-		{
-			if (needInit)
-			{
-				needInit = false;
-				return true;
-			}
-			return false;
-		}
-
-	private:
-		bool needInit = true;
 	};
 
 	/**

--- a/src/scheduler/scheduler.cpp
+++ b/src/scheduler/scheduler.cpp
@@ -34,6 +34,8 @@ namespace Scheduler
 		static EventGroupHandle_t s_tasksEventGroup = xEventGroupCreate();
 		static EventBits_t s_startedTaskBits = 0;
 
+		static time_t s_schedulerStartTime = time(nullptr);
+
 		/**
 		 * Struct that holds information needed by the TaskWrapper.
 		 */
@@ -145,6 +147,8 @@ namespace Scheduler
 				// Reset started task bits and count.
 				s_startedTaskBits = 0;
 				int startedTasks = 0;
+
+				s_schedulerStartTime = time(nullptr);
 
 				// Loop over every task.
 				for (const auto &task : s_tasks)
@@ -260,6 +264,8 @@ namespace Scheduler
 
 	void RunAll()
 	{
+		s_schedulerStartTime = time(nullptr);
+
 		// Reset started task bits and count.
 		s_startedTaskBits = 0;
 		int startedTasks = 0;
@@ -306,8 +312,7 @@ namespace Scheduler
 	{
 		// Round down the time to full minutes,
 		// since the intervals will never be smaller than 1 minute.
-		auto now = time(nullptr);
-		auto currentTime = localtime(&now);
+		auto currentTime = localtime(&s_schedulerStartTime);
 
 		currentTime->tm_sec = 0;
 


### PR DESCRIPTION
Trello: https://trello.com/c/wgBKh6pz

The current measurement time used to be based on the current time, which could cause timestamps to diverge by 1 minute. The current measurement time is now based on when the scheduler started.