### PR TITLE
Always log booted_fw after provisioning

### DIFF
--- a/src/generic_esp_32/generic_esp_32.cpp
+++ b/src/generic_esp_32/generic_esp_32.cpp
@@ -29,10 +29,7 @@
 #include <generic_tasks.hpp>
 #include <measurements.hpp>
 #include <secure_upload.hpp>
-
-#ifdef CONFIG_TWOMES_OTA_FIRMWARE_UPDATE
 #include <ota_firmware_updater.hpp>
-#endif // CONFIG_TWOMES_OTA_FIRMWARE_UPDATE
 
 #ifdef CONFIG_TWOMES_PROV_TRANSPORT_BLE
 #include <wifi_provisioning/scheme_ble.h>
@@ -447,11 +444,10 @@ namespace GenericESP32Firmware
         {
             // Immediately sync time.
             InitializeTimeSync();
-#ifdef CONFIG_TWOMES_OTA_FIRMWARE_UPDATE
+
             // Log the booted firmware version to the backend.
             auto appDescription = esp_ota_get_app_description();
             OTAFirmwareUpdater::LogFirmwareToBackend("booted_fw", appDescription->version);
-#endif // CONFIG_TWOMES_OTA_FIRMWARE_UPDATE
 
             ESP_LOGD(TAG, "Sending a heartbeat once.");
             // Add a measurement formatter for the heartbeat property.


### PR DESCRIPTION
## Information
Trello: https://trello.com/c/rGqhyCuJ

Previously, booted_fw was only logged when OTA firmware updates were enabled. This is no longer the case. booted_fw is now always logged after provisioning.

## Test
I tested this using the https://github.com/energietransitie/twomes-scd41-presence-firmware repository.

![image](https://user-images.githubusercontent.com/43145188/198016173-043e8cc3-ff30-484d-ae4b-bf536b31ec32.png)
