### PR TITLE
Power M5CoreInk off after 15 minutes awaiting provisioning

### DIFF
--- a/include/specific_m5coreink/power_off_timeout.hpp
+++ b/include/specific_m5coreink/power_off_timeout.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <string>
+
+#include <esp_err.h>
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
+namespace M5CoreInkSpecific
+{
+    /**
+     * PowerOffTimeout will power off the M5CoreInk after a specified timeout.
+     */
+    class PowerOffTimeout
+    {
+    public:
+        PowerOffTimeout() = delete;
+        PowerOffTimeout(const PowerOffTimeout &) = delete;
+        PowerOffTimeout(PowerOffTimeout &&) = delete;
+
+        /**
+         * Create a new PowerOffTimeout object.
+         * The device will power off after the timeout.
+         *
+         * @param timeout_s Timout in seconds.
+         */
+        PowerOffTimeout(int timeout_s);
+
+        /**
+         * Start the timout.
+         * When the timeout ends before it is canceled,
+         * the device will be powered off.
+         *
+         * When start is called more than once, the timer keeps running. It is not reset.
+         */
+        void Start();
+
+        /**
+         * Cancel the timout.
+         *
+         * If the timout is not running, nothing will happen.
+         */
+        void Cancel();
+
+    private:
+        int m_timeout_s;
+
+        TaskHandle_t m_taskHandle;
+    };
+} // namespace M5CoreInkSpecific

--- a/src/specific_m5coreink/power_off_timeout.cpp
+++ b/src/specific_m5coreink/power_off_timeout.cpp
@@ -1,0 +1,62 @@
+#include <specific_m5coreink/power_off_timeout.hpp>
+
+#include <esp_log.h>
+
+#include <specific_m5coreink/powerpin.h>
+#include <util/delay.hpp>
+#include <util/screen.hpp>
+
+constexpr const char *TAG = "PowerOffTimeout";
+
+namespace M5CoreInkSpecific
+{
+    namespace
+    {
+        void TimoutFunction(void *pvParams)
+        {
+            auto timeout = static_cast<int *>(pvParams);
+
+            vTaskDelay(Delay::Seconds(*timeout));
+
+            Screen screen;
+            screen.Clear();
+
+            // Allow some time for the screen to clear properly.
+            vTaskDelay(Delay::MilliSeconds(300));
+
+            // Power off the M5CoreINK.
+            powerpin_reset();
+
+            vTaskDelete(nullptr);
+        }
+    } // namespace
+
+    PowerOffTimeout::PowerOffTimeout(int timeout_s)
+        : m_timeout_s(timeout_s) {}
+
+    void PowerOffTimeout::Start()
+    {
+        auto err = xTaskCreatePinnedToCore(TimoutFunction,
+                                           "PowerOffTimeout",
+                                           4096,
+                                           static_cast<void *>(&m_timeout_s),
+                                           1,
+                                           &m_taskHandle,
+                                           APP_CPU_NUM);
+
+        if (err != pdPASS)
+        {
+            ESP_LOGE(TAG, "PowerOffTimeout task failed to start.");
+        }
+    }
+
+    void PowerOffTimeout::Cancel()
+    {
+        if (m_taskHandle == nullptr)
+        {
+            return;
+        }
+
+        vTaskDelete(m_taskHandle);
+    }
+} // namespace M5CoreInkSpecific

--- a/src/util/screen.cpp
+++ b/src/util/screen.cpp
@@ -17,7 +17,9 @@ Screen::Screen()
 
 void Screen::Clear()
 {
+	m_display.setEpdMode(epd_mode_t::epd_quality);
 	m_display.clear();
+	m_display.setEpdMode(epd_mode_t::epd_text);
 }
 
 void Screen::DisplayQR(const std::string &payload, int padding, const std::string &text)


### PR DESCRIPTION
The e-ink display is cleared. No text is displayed. If we want to do this, we should create another trello card to implement this feature, since this is currently not possible.