### PR TITLE
Mention waiting for platformIO to finish init

### DIFF
--- a/docs/starting/prerequisites.md
+++ b/docs/starting/prerequisites.md
@@ -23,10 +23,12 @@ Prerequisites are [the prerequisites for deploying](../deploying/prerequisites.m
 ## Coding and uploading
 We recommend using a device without [secure boot](../releasing/secure-boot-firmware.md) for developing. Follow the steps below to build the firmware and flash it to a device:
 
-  1. In the top-left corner, select File -> Open Folder.
-  2. Select the folder where you cloned or extracted the repository.
-  3. In the `src` folder you will find `main.cpp`; this is an example application.
-  4. In the `lib` folder you will find the library that this repository contains.
-  5. To change between provisioning via BLE or SoftAP, in the `platformio.ini`file, comment the line including `-DCONFIG_EXAMPLE_PROV_TRANSPORT_BLE` and uncomment the line including `-DCONFIG_EXAMPLE_PROV_TRANSPORT_SOFTAP` or vice versa.
-  6. Change the code in `src/main.c` as you see fit.
-  7. Build the firmware. See also our documentation on how to [build Twomes firmware](../releasing/building.md)
+1. In the top-left corner, select File -> Open Folder.
+2. Select the folder where you cloned or extracted the repository.
+3. Wait for PlatformIO to finish initialization. This step is done until you no longer see "PlatformIO: Loading tasks..." in the VS Code status bar.
+	> ⚠️ This step is important! This may take up to ±10 minutes. If you do not wait for this to finish, the project will not be able to build correctly.
+4. In the `src` folder you will find `main.cpp`; this is an example application.
+5. In the `lib` folder you will find the library that this repository contains.
+6. To change between provisioning via BLE or SoftAP, in the `platformio.ini`file, comment the line including `-DCONFIG_EXAMPLE_PROV_TRANSPORT_BLE` and uncomment the line including `-DCONFIG_EXAMPLE_PROV_TRANSPORT_SOFTAP` or vice versa.
+7. Change the code in `src/main.c` as you see fit.
+8. Build the firmware. See also our documentation on how to [build Twomes firmware](../releasing/building.md)


### PR DESCRIPTION
Not waiting for initialisation caused problems with building the repository in the past.