### PR TITLE
API v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,12 +53,6 @@ jobs:
       # Setup PlatformIO.
       - name: Setup PlatformIO
         run: pip install platformio
-        
-      # Change library from github to local directory in platformio.ini.
-      - name: Use local library version
-        env:
-          TEST_DIR: ${{ matrix.test_dir }}
-        run: sed -i 's=https://github.com/energietransitie/twomes-generic-esp-firmware=../../=g' $TEST_DIR/platformio.ini
       
       # Build the PlatformIO project.
       - name: Build PlatformIO project

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Different Twomes measurement devices may have various features in common, includ
 | Sensor | Property or *timestamp*           | Unit | [Printf format](https://en.wikipedia.org/wiki/Printf_format_string) | Default measurement interval \[h:mm:ss\] | Description                            |
 |--------|--------------------|------|--------|-------------------|----------------------------------------|
 | [ESP32](https://en.wikipedia.org/wiki/ESP32)  | `heartbeat` |   | %d     | 0:10:00           | Incrementing counter indicating the device is working                       |
-| [ESP32](https://en.wikipedia.org/wiki/ESP32)  | `batteryVoltage` | V  | %.2f   | 0:10:00           | Measures the battery voltage                      |
-| [ESP32](https://en.wikipedia.org/wiki/ESP32) Bluetooth  | `countPresence`         | [-]   | %u   | 0:10:00           | If enabled; number of smartphones responding to Bluetooth name request                        |
+| [ESP32](https://en.wikipedia.org/wiki/ESP32)  | `battery_voltage__V` | V  | %.2f   | 0:10:00           | Measures the battery voltage                      |
+| [ESP32](https://en.wikipedia.org/wiki/ESP32) Bluetooth  | `occupancy__p`         | [-]   | %u   | 0:10:00           | If enabled; number of smartphones responding to Bluetooth name request                        |
 | [ESP32](https://en.wikipedia.org/wiki/ESP32) device clock  | *`timestamp`* | [Unix time](https://en.wikipedia.org/wiki/Unix_time)   | %d   | 0:10:00           | Each measurement is timestamped |
 | [ESP32](https://en.wikipedia.org/wiki/ESP32) device clock  | *`upload_time`* | [Unix time](https://en.wikipedia.org/wiki/Unix_time)   | %d   | 0:10:00           | Uploads of the contents of the secure upload queue to a [Twomes server](https://github.com/energietransitie/twomes-backoffice-configuration) are timestamped |
 | [ESP32](https://en.wikipedia.org/wiki/ESP32) internet | `booted_fw`         | version   | %s   | 48:00:00           | Version string of firmware on first boot after provisioning or OTA update                        |

--- a/docs/deploying/device-preparation.md
+++ b/docs/deploying/device-preparation.md
@@ -54,33 +54,7 @@ After this command you should perform the full Twomes device preparation flow be
 > - `python3 -m esptool` or
 > - `esptool.py`.
 
-## Step 2: Find the device name and activation_token
-
-1. Open your serial monitor utility.
-	*  For [PuTTY](https://www.chiark.greenend.org.uk/~sgtatham/putty/), use the following destination settings (be sure to `Save` them to `Load` them conveniently later):
-		* Connection type: `Serial`
-		* Speed: `115200`
-		* Serial line: `COM?` (replace `?` with the number of the COM-port your device is connected to, e.g., `COM5`). 
-2. Once your device is powered up (and running), briefly press the reset button.
-3. You will be able to see all the boot logs of the device in the serial monitor. Somewhere in the logs, you will find the JSON payload needed to active the device on the [Twomes server](https://github.com/energietransitie/twomes-backoffice-configuration) using the [Twomes API](https://github.com/energietransitie/twomes-backoffice-api).
-
-	```json5 title="Example JSON payload inside device logs"
-	{
-		"name":"TWOMES-D3AD48",
-		"device_type":"DSMR-P1-gateway-TinTsTrCO2",
-		"activation_token":"3375550652"
-	}
-	```
-
-## Step 3: Register the device on the [Twomes server](https://github.com/energietransitie/twomes-backoffice-configuration) using the [Twomes API](https://github.com/energietransitie/twomes-backoffice-api)
-
-In order to create a device on the [Twomes server](https://github.com/energietransitie/twomes-backoffice-configuration) using the [Twomes API](https://github.com/energietransitie/twomes-backoffice-api), you need the JSON payload which you found in [step 2](#step-2-find-a-devices-name-and-activationtoken).
-
-Read the [Twomes API documentation](https://api.energietransitiewindesheim.nl/docs#/default/device_create_device_post) to see how you can use the [Twomes API](https://github.com/energietransitie/twomes-backoffice-api) to create the device. 
-
-You will need an admin bearer session token in order to use this endpoint. Refer to [this section on the Twomes API](https://github.com/energietransitie/twomes-backoffice-api#deploying-new-admin-accounts-to-apitstenergietransitiewindesheimnl) on how to obtain one.
-
-## Step 4: Generating a QR-code
+## Step 2: Generating a QR-code
 > For measurement devices that use the [M5Stack CoreInk](https://github.com/m5stack/M5-CoreInk), this step can be skipped, since the firmware automatically displays the QR-code on the e-ink screen of the device.<
 
 The `device.name` and `device.activation_token` of the device should be encoded in a QR-code that visible to the subject that receives the Twomes measurement device. When printed on a sticker, we recomend attaching it the back of the measurement device.

--- a/include/generic_esp_32.hpp
+++ b/include/generic_esp_32.hpp
@@ -4,9 +4,9 @@
 
 #include <util/http_util.hpp>
 
-constexpr const char *ENDPOINT_VARIABLE_UPLOAD = "/device/measurements/variable-interval";
-constexpr const char *ENDPOINT_FIXED_INTERVAL_UPLOAD = "/device/measurements/fixed-interval";
-constexpr const char *ENDPOINT_DEVICE_ACTIVATION = "/device/activate";
+constexpr const char *ENDPOINT_VARIABLE_UPLOAD = "/v2/upload";
+constexpr const char *ENDPOINT_FIXED_INTERVAL_UPLOAD = "/v2/device/measurements/fixed-interval"; // Deprecated.
+constexpr const char *ENDPOINT_DEVICE_ACTIVATION = "/v2/device/activate";
 
 namespace GenericESP32Firmware
 {
@@ -39,13 +39,17 @@ namespace GenericESP32Firmware
      *
      * @param endpoint API endpoint.
      * @param dataSend Data to send in the POST request.
+     * @param headersSend Headers to send in the POST request.
      * @param dataReceive Response data from the POST request.
+     * @param headersReceive Response headers from the POST request.
      * @param useBearer Optional parameter (default true) to use bearer or not.
      *
      * @returns HTTP status code.
      */
     int PostHTTPSToBackend(const std::string &endpoint,
                            HTTPUtil::buffer_t &dataSend,
+                           HTTPUtil::headers_t &headersSend,
                            HTTPUtil::buffer_t &dataReceive,
-                           bool useBearer = true);
+                           HTTPUtil::headers_t &headersReceive,
+                           bool useBearer);
 } // namespace GenericESP32Firmware

--- a/src/generic_esp_32/generic_esp_32.cpp
+++ b/src/generic_esp_32/generic_esp_32.cpp
@@ -9,6 +9,7 @@
 #include <wifi_provisioning/manager.h>
 #include <driver/gpio.h>
 #include <esp_sntp.h>
+#include <esp32/rom/crc.h>
 
 #include <freertos/FreeRTOS.h>
 #include <freertos/event_groups.h>
@@ -759,13 +760,13 @@ namespace GenericESP32Firmware
 
     std::string GetDeviceServiceName()
     {
-        // TODO: hash device type + add mac.
+        uint16_t deviceTypeHash = ~crc16_be((uint16_t)~0x0000, (const uint8_t *)s_deviceTypeName.c_str(), s_deviceTypeName.length());
 
         uint8_t eth_mac[6];
         auto err = esp_wifi_get_mac(WIFI_IF_STA, eth_mac);
         Error::CheckAppendName(err, TAG, "An error occured when getting ETH MAC");
 
-        return Format::String("%s%02X%02X%02X", DEVICE_SERVICE_NAME_PREFIX, eth_mac[3], eth_mac[4], eth_mac[5]);
+        return Format::String("%04X-%02X%02X%02X", deviceTypeHash, eth_mac[3], eth_mac[4], eth_mac[5]);
     }
 
     void InitializeTimeSync()

--- a/src/ota_firmware_updater/ota_firmware_updater.cpp
+++ b/src/ota_firmware_updater/ota_firmware_updater.cpp
@@ -274,7 +274,7 @@ namespace OTAFirmwareUpdater
         // Initialize Measurement formatter.
         Measurements::Measurement::AddFormatter(propertyName, "%s");
 
-        Measurements::Measurement measurement(propertyName, version.c_str());
+        Measurements::Measurement measurement(propertyName, version.c_str(), time(nullptr));
         secureUploadQueue.AddMeasurement(measurement);
     }
 } // namespace OTAFirmwareUpdater

--- a/src/presence_detection/presence_detection.cpp
+++ b/src/presence_detection/presence_detection.cpp
@@ -33,7 +33,7 @@ constexpr int RESPONSE_MAX_WAIT_MS = 20 * 1000; // 20 seconds.
 constexpr int RESPONSE_MAX_WAIT_MS = 10 * 1000; // 10 seconds.
 #endif // CONFIG_TWOMES_PRESENCE_DETECTION_PARALLEL
 
-constexpr const char *MEASUREMENT_PROPERTY_NAME = "countPresence";
+constexpr const char *MEASUREMENT_PROPERTY_NAME = "occupancy__p";
 
 // Event for when all sent responses have returned.
 constexpr EventBits_t EVENT_RESPONSES_FINISHED = 1 << 0;

--- a/src/secure_upload/measurements.cpp
+++ b/src/secure_upload/measurements.cpp
@@ -13,29 +13,25 @@ namespace Measurements
 
 	cJSON *Measurement::GetJSON()
 	{
-		// Create the object that eventually gets added to "property_measurements".
-		auto propertyMeasurementObject = cJSON_CreateObject();
+		// Create the object that eventually gets added to "measurements".
+		auto measurementObject = cJSON_CreateObject();
 
-		// Add the property name to the object.
+		// Add the property object.
+		auto propertyObject = cJSON_CreateObject();
+		cJSON_AddItemToObject(measurementObject, "property", propertyObject);
+
+		// Add the property name to the property object.
 		auto propertyName = cJSON_CreateString(m_propertyName.c_str());
-		cJSON_AddItemToObject(propertyMeasurementObject, "property_name", propertyName);
-
-		// Add a measurements array to the object.
-		auto measurements = cJSON_CreateArray();
-		cJSON_AddItemToObject(propertyMeasurementObject, "measurements", measurements);
-
-		// Add a new measurement object to the measurements array.
-		auto measurement = cJSON_CreateObject();
-		cJSON_AddItemToArray(measurements, measurement);
+		cJSON_AddItemToObject(propertyObject, "name", propertyName);
 
 		// Add the measurement timestamp to the measurement object.
 		auto timestamp = cJSON_CreateNumber(m_timestamp);
-		cJSON_AddItemToObject(measurement, "timestamp", timestamp);
+		cJSON_AddItemToObject(measurementObject, "time", timestamp);
 
 		// Add the measurement value to the measurement object.
 		auto value = cJSON_CreateString(m_value.c_str());
-		cJSON_AddItemToObject(measurement, "value", value);
+		cJSON_AddItemToObject(measurementObject, "value", value);
 
-		return propertyMeasurementObject;
+		return measurementObject;
 	}
 } // namespace Measurements

--- a/src/secure_upload/secure_upload.cpp
+++ b/src/secure_upload/secure_upload.cpp
@@ -40,13 +40,13 @@ namespace SecureUpload
 	{
 		auto uploadObject = cJSON_CreateObject();
 
-		// Add upload time.
+		// Add device upload time.
 		auto uploadTime = cJSON_CreateNumber(time(nullptr));
-		cJSON_AddItemToObject(uploadObject, "upload_time", uploadTime);
+		cJSON_AddItemToObject(uploadObject, "device_time", uploadTime);
 
-		// add property_measurements array
-		auto propertyMeasurements = cJSON_CreateArray();
-		cJSON_AddItemToObject(uploadObject, "property_measurements", propertyMeasurements);
+		// Ddd measurements array
+		auto measurements = cJSON_CreateArray();
+		cJSON_AddItemToObject(uploadObject, "measurements", measurements);
 
 		int measurementItems = 0;
 
@@ -56,7 +56,7 @@ namespace SecureUpload
 			if (xQueueReceive(m_measurementQueue, &item, 0) != pdTRUE)
 				break;
 
-			cJSON_AddItemToArray(propertyMeasurements, item->GetJSON());
+			cJSON_AddItemToArray(measurements, item->GetJSON());
 			delete item;
 
 			measurementItems++;
@@ -70,9 +70,11 @@ namespace SecureUpload
 		}
 
 		HTTPUtil::buffer_t dataSend = cJSON_Print(uploadObject);
+		HTTPUtil::headers_t headersSend;
 		HTTPUtil::buffer_t dataReceive;
+		HTTPUtil::headers_t headersReceive;
 
-		auto statusCode = GenericESP32Firmware::PostHTTPSToBackend(ENDPOINT_VARIABLE_UPLOAD, dataSend, dataReceive);
+		auto statusCode = GenericESP32Firmware::PostHTTPSToBackend(ENDPOINT_VARIABLE_UPLOAD, dataSend, headersSend, dataReceive, headersReceive, true);
 		if (statusCode != 200)
 		{
 			ESP_LOGE(TAG, "Posting to backend returned statuscode %d.", statusCode);

--- a/src/specific_m5coreink/battery_voltage.cpp
+++ b/src/specific_m5coreink/battery_voltage.cpp
@@ -6,7 +6,7 @@
 #include <secure_upload.hpp>
 #include <measurements.hpp>
 
-constexpr const char *MEASUREMENT_PROPERTY_NAME = "batteryVoltage";
+constexpr const char *MEASUREMENT_PROPERTY_NAME = "battery_voltage__V";
 
 namespace M5CoreInkSpecific
 {

--- a/test/generic-test/platformio.ini
+++ b/test/generic-test/platformio.ini
@@ -32,7 +32,7 @@ board_build.partitions = partitions.csv
 
 framework = espidf
 
-lib_deps = https://github.com/energietransitie/twomes-generic-esp-firmware
+lib_deps = ../../
 
 ;Build and Debug settings:
 build_flags = 


### PR DESCRIPTION
<!-- 
Please fill out the entire template where applicable. 
You don't need to remove the comments. They won't show up in the pull request.
-->

## What does this change
<!-- Please describe the changes you made. -->
- The generic firmware now uses API v2 to:
    - Activate itself
    - Upload measurements
- Uses the device_type.info_url as the post-provisioning QR-code.
- Small fix: device firmware version measurement now also has correct time when RTC was without power.

## Testing
<!--
Please check only one of these boxes.
Remove the space and place an 'x' inside the box to check it.
-->
- [ ] This change does not need testing.
- [x] I tested this change.
- [ ] I did not test this change.

<!-- Describe how you tested this change (if applicable). -->
I used https://github.com/energietransitie/twomes-scd41-presence-firmware to test this. I made a change to [this line](https://github.com/energietransitie/twomes-scd41-presence-firmware/blob/4000d11d5f3d30008775671919436979963bf674/platformio.ini#L35):
```diff
- lib_deps = https://github.com/energietransitie/twomes-generic-esp-firmware#v3.0.0
+ lib_deps = https://github.com/energietransitie/twomes-generic-esp-firmware#api-v2
```

I then built the firmware for the test server and tested the changes.
- [x] The device can activate itself correctly.
- [x] The device can upload measurements correctly. 

> **Note**
> The app does not yet support API v2, so I had to manually do the API calls that the app will do in the future.

## Trello card(s)
<!-- Please add applicable trello cards here like this:
- Card title: https://trello.com/c/PhICfOYC
-->
- Update twomes-generic-esp-firmware using APIv2: https://trello.com/c/z17zUUFw