### PR TITLE
Fix: disconnect after onboarding + better stability

### DIFF
--- a/include/control_panel.hpp
+++ b/include/control_panel.hpp
@@ -10,6 +10,11 @@ namespace ControlPanel
 {
     extern Menu menuState;
 
+    /**
+     * Exit the onboarding screen.
+     */
+    void ExitOnboardingScreen();
+
      /**
      * InitilizeButtons.
      * 

--- a/include/presence_detection.hpp
+++ b/include/presence_detection.hpp
@@ -17,6 +17,13 @@ namespace PresenceDetection
     struct InitializeOptions
     {
         /**
+         * Enable Bluetooth;
+         * The entire Bluetooth stack will be enabled.
+         * Only use this if BT stack is not yet enabled.
+         */
+        bool EnableBluetooth;
+
+        /**
          * Enable A2DP sink.
          * This should be enabled if you want an iPhone to be able to pair.
          */

--- a/src/presence_detection/presence_detection.cpp
+++ b/src/presence_detection/presence_detection.cpp
@@ -304,31 +304,18 @@ namespace PresenceDetection
 			if (Error::CheckAppendName(err, TAG, "An error occured when setting device name"))
 				return err;
 
-			// The callback should only be registered once during runtime.
-			static bool callbackRegistered = false;
-			if (!callbackRegistered)
-			{
-				err = esp_bt_gap_register_callback(GapCallback);
-				if (Error::CheckAppendName(err, TAG, "An error occured when registering GAP callback"))
-					return err;
-
-				callbackRegistered = true;
-			}
+			err = esp_bt_gap_register_callback(GapCallback);
+			if (Error::CheckAppendName(err, TAG, "An error occured when registering GAP callback"))
+				return err;
 		}
 
 		if (options.EnableA2DPSink)
 		{
 			ESP_LOGD(TAG, "Enabling A2DP");
 
-			static bool callBackRegistered = false;
-			if (!callBackRegistered)
-			{
-				err = esp_a2d_register_callback(A2DPCallback);
-				if (Error::CheckAppendName(err, TAG, "An error occured when registering A2DP callback"))
-					return err;
-
-				callBackRegistered = true;
-			}
+			err = esp_a2d_register_callback(A2DPCallback);
+			if (Error::CheckAppendName(err, TAG, "An error occured when registering A2DP callback"))
+				return err;
 
 			err = esp_a2d_sink_init();
 			if (Error::CheckAppendName(err, TAG, "An error occured when initializing A2DP sink"))

--- a/src/presence_detection/presence_detection.cpp
+++ b/src/presence_detection/presence_detection.cpp
@@ -182,11 +182,8 @@ namespace PresenceDetection
 				// Buzz the buzzer for 200 ms to signal the devices are paired.
 				Buzzer::Buzz(200);
 
-				// imitate a button press that pressed return.
-				if (ControlPanel::menuState == Menu::create_onboarded)
-				{
-					ControlPanel::OnboardingMenuState(ButtonActions::press);
-				}
+				ControlPanel::ExitOnboardingScreen();
+
 				break;
 			default:
 				break;

--- a/src/presence_detection/presence_detection.cpp
+++ b/src/presence_detection/presence_detection.cpp
@@ -489,6 +489,10 @@ namespace PresenceDetection
 			s_initialized = true;
 		}
 
+		// At this time, we can't run onboarding and presence detection at the same time.
+		// This is a temporary fix, to wait until onboarding is done.
+		WaitIfBluetoothActive();
+
 		InitializeOptions initOptions{};
 		initOptions.EnableA2DPSink = false;
 		initOptions.EnableDiscoverable = false;


### PR DESCRIPTION
The phone now correctly disconnects and the devices buzzes and returns from the onboarding page without issues.

Not performing presence detection and its onboarding at the same time greatly increases stability and reduces crashes.